### PR TITLE
Updates gradle build for compatibility with 7.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,16 +20,16 @@ repositories {
 }
 
 dependencies {
-    compile "net.dv8tion:JDA:4.3.0_291"
+    implementation "net.dv8tion:JDA:4.3.0_291"
 //    compile "com.sedmelluq:lavaplayer:1.3.42"
-    compile "com.jgoodies:jgoodies-forms:1.9.0"
-    compile "com.jgoodies:jgoodies-common:1.8.1"
-    compile "com.jgoodies:jgoodies-looks:2.7.0"
-    compile "com.google.code.gson:gson:2.8.6"
-    compile "org.apache.commons:commons-lang3:3.9"
+    implementation "com.jgoodies:jgoodies-forms:1.9.0"
+    implementation "com.jgoodies:jgoodies-common:1.8.1"
+    implementation  "com.jgoodies:jgoodies-looks:2.7.0"
+    implementation "com.google.code.gson:gson:2.8.6"
+    implementation "org.apache.commons:commons-lang3:3.9"
 //    compile "org.slf4j:slf4j-simple:1.7.30"
-    compile "ch.qos.logback:logback-classic:1.0.13"
-    compile files("libs/NativeBass.jar")
+    implementation "ch.qos.logback:logback-classic:1.0.13"
+    implementation files("libs/NativeBass.jar")
 }
 
 mainClassName = 'net.runee.gui.MainFrame'


### PR DESCRIPTION
This updates `gradle.build` to use the newer syntax. 

Tested on Gradle 7.0 and 7.1.1 and have successful builds on both. 